### PR TITLE
Windows behavior fixed

### DIFF
--- a/django_selectel_storage/storage.py
+++ b/django_selectel_storage/storage.py
@@ -10,6 +10,7 @@ from django.conf import settings
 import os
 import selectel
 import requests
+import urllib.parse
 
 
 MAX_RETRIES = 3
@@ -104,7 +105,7 @@ class SelectelStorage(DjangoStorage):
             raise IOError('Unable get size for %s' % name)
 
     def url(self, name):
-        return os.path.join(self.get_base_url().rstrip('/'),  name.lstrip('/'))
+        return urllib.parse.urljoin(self.get_base_url().rstrip("/") + "/", name.lstrip('/'))
 
 
 class SelectelStaticStorage(SelectelStorage):

--- a/django_selectel_storage/storage.py
+++ b/django_selectel_storage/storage.py
@@ -7,10 +7,13 @@ from __future__ import division
 from django.core.files.storage import Storage as DjangoStorage
 from django.core.files.base import ContentFile
 from django.conf import settings
-import os
 import selectel
 import requests
-import urllib.parse
+
+try:  # PY3
+    import urllib.parse as urlparse
+except ImportError:  # PY2
+    import urlparse
 
 
 MAX_RETRIES = 3
@@ -105,7 +108,9 @@ class SelectelStorage(DjangoStorage):
             raise IOError('Unable get size for %s' % name)
 
     def url(self, name):
-        return urllib.parse.urljoin(self.get_base_url().rstrip("/") + "/", name.lstrip('/'))
+        return urlparse.urljoin(
+            self.get_base_url().rstrip("/") + "/",
+            name.lstrip('/'))
 
 
 class SelectelStaticStorage(SelectelStorage):


### PR DESCRIPTION
Unfortunatelly, os.path.join isn't a crossplatform method for url merging.
